### PR TITLE
seperate routing responsibility from handler

### DIFF
--- a/src/api/gear.rs
+++ b/src/api/gear.rs
@@ -2,8 +2,7 @@ use crate::Gear;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
-    routing::get,
-    Json, Router,
+    Json,
 };
 use sea_orm::{DatabaseConnection, EntityTrait};
 use serde::Serialize;
@@ -11,7 +10,7 @@ use serde::Serialize;
 use crate::entity::gear;
 
 #[derive(Serialize)]
-struct GearResponse {
+pub struct GearResponse {
     id: i32,
     name: String,
 }
@@ -25,17 +24,7 @@ impl From<gear::Model> for GearResponse {
     }
 }
 
-pub struct GearRouter;
-
-impl GearRouter {
-    pub fn initialize() -> Router<sea_orm::DatabaseConnection> {
-        Router::new()
-            .route("/get_all", get(get_all_gear))
-            .route("/get/{gear_id}", get(get_by_id))
-    }
-}
-
-async fn get_all_gear(
+pub async fn get_all(
     State(db): State<DatabaseConnection>,
 ) -> Result<Json<Vec<GearResponse>>, StatusCode> {
     let gear = Gear::find()
@@ -45,7 +34,7 @@ async fn get_all_gear(
     Ok(Json(gear.into_iter().map(GearResponse::from).collect()))
 }
 
-async fn get_by_id(
+pub async fn get_by_id(
     State(db): State<DatabaseConnection>,
     Path(gear_id): Path<i32>,
 ) -> Result<Json<Vec<GearResponse>>, StatusCode> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,18 @@
 mod api;
 mod database;
 mod entity;
+mod routes;
 
-use axum::Router;
 use entity::prelude::Gear;
 use sea_orm::DatabaseConnection;
 
-use crate::{api::gear::GearRouter, database::database_utils::make_database_connection};
+use crate::{database::database_utils::make_database_connection};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database_connection: DatabaseConnection = make_database_connection().await;
 
-    let gear_router = GearRouter::initialize();
-
-    let app = Router::new()
-        .nest("/gear", gear_router)
-        .with_state(database_connection);
+    let app = routes::api::routes(database_connection);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
     axum::serve(listener, app).await?;

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -1,0 +1,12 @@
+use axum::{
+    Router,
+};
+use crate::routes::{gear};
+
+pub fn routes(db: sea_orm::DatabaseConnection) -> Router{
+    let gear_router = gear::routes();
+    let router = Router::new()
+        .nest("/gear", gear_router)
+        .with_state(db);
+    router
+}

--- a/src/routes/gear.rs
+++ b/src/routes/gear.rs
@@ -1,0 +1,12 @@
+use axum::{
+    routing::get,
+    Router,
+};
+use crate::api::gear;
+
+pub fn routes() -> axum::Router<sea_orm::DatabaseConnection>{
+    let router = Router::new()
+        .route("/{id}", get(gear::get_by_id))
+        .route("/", get(gear::get_all));
+    router
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod gear;


### PR DESCRIPTION
- Separates the responsibility of routing into it's own crate.
- Changed endpoints to be more in line with RESTful resource identifiers.
